### PR TITLE
fix(saas): PR #12 review follow-ups (#11-16 hardening/cleanup)

### DIFF
--- a/src/connection/auth/ntlm-provider.ts
+++ b/src/connection/auth/ntlm-provider.ts
@@ -2,6 +2,7 @@ import * as cheerio from 'cheerio';
 import { ok, err, type Result } from '../../core/result.js';
 import { AuthenticationError } from '../../core/errors.js';
 import { bindingFromBaseUrl, type IBCAuthProvider, type AuthResult, type ConnectionBinding } from './auth-provider.js';
+import { mergeSetCookies } from './set-cookie-merge.js';
 import type { Logger } from '../../core/logger.js';
 
 interface NTLMProviderConfig {
@@ -32,7 +33,7 @@ export class NTLMAuthProvider implements IBCAuthProvider {
       });
 
       const setCookies = getResponse.headers.getSetCookie?.() ?? [];
-      this.cookies = setCookies.map(c => c.split(';')[0]!).join('; ');
+      this.cookies = mergeSetCookies('', setCookies);
 
       const html = await getResponse.text();
       const $ = cheerio.load(html);
@@ -76,23 +77,10 @@ export class NTLMAuthProvider implements IBCAuthProvider {
         }
       }
 
-      // Merge updated cookies
+      // Merge updated cookies (honors server cookie deletions via Max-Age/Expires)
       const postCookies = postResponse.headers.getSetCookie?.() ?? [];
       if (postCookies.length > 0) {
-        const existingMap = new Map(this.cookies.split('; ').filter(c => c).map(c => {
-          const eqIdx = c.indexOf('=');
-          return eqIdx >= 0 ? [c.substring(0, eqIdx), c.substring(eqIdx + 1)] as [string, string] : [c, ''] as [string, string];
-        }));
-        for (const cookie of postCookies) {
-          const [nameValue] = cookie.split(';');
-          if (nameValue) {
-            const eqIdx = nameValue.indexOf('=');
-            if (eqIdx >= 0) {
-              existingMap.set(nameValue.substring(0, eqIdx), nameValue.substring(eqIdx + 1));
-            }
-          }
-        }
-        this.cookies = Array.from(existingMap.entries()).map(([k, v]) => `${k}=${v}`).join('; ');
+        this.cookies = mergeSetCookies(this.cookies, postCookies);
       }
 
       // Extract CSRF token from antiforgery cookie. Prefer the cookie whose

--- a/src/connection/auth/oauth-provider.ts
+++ b/src/connection/auth/oauth-provider.ts
@@ -6,6 +6,7 @@ import { bindingFromBaseUrl, type IBCAuthProvider, type AuthResult, type Connect
 import { isSaasHost } from '../saas-url.js';
 import { OAuthTokenClient, type TokenSet } from './oauth-token-client.js';
 import { FileTokenCache, FilePendingDeviceCache } from './token-cache.js';
+import { mergeSetCookies } from './set-cookie-merge.js';
 
 export interface OAuthProviderConfig {
   baseUrl: string;
@@ -209,9 +210,13 @@ export class OAuthAuthProvider implements IBCAuthProvider {
       if (oauthError === 'authorization_pending' || oauthError === 'slow_down') {
         return err(new DeviceLoginRequiredError(pending.verificationUri, pending.userCode, pending.expiresAt));
       }
-      if (oauthError === undefined || String(oauthError).startsWith('http_5')) {
-        // Network or transient token-endpoint failure — keep the pending
-        // code; the user may be mid-sign-in.
+      if (oauthError === undefined || String(oauthError).startsWith('http_')) {
+        // Network or ambiguous token-endpoint response — keep the pending
+        // code; the user may be mid-sign-in. A real hard failure
+        // (expired_token, access_denied) always carries a JSON `error` field,
+        // so it surfaces as that code, never a synthetic `http_<status>`
+        // (which means the response had no OAuth error body: a captive
+        // portal 200/302, a bodyless 4xx, or a 5xx).
         return polled;
       }
       this.pending.clear();
@@ -334,21 +339,7 @@ function hostnameOf(raw: string): string {
   }
 }
 
-export function mergeSetCookies(existing: string, setCookieHeaders: string[]): string {
-  const map = new Map<string, string>();
-  for (const part of existing.split('; ').filter(Boolean)) {
-    const eq = part.indexOf('=');
-    if (eq >= 0) map.set(part.slice(0, eq), part.slice(eq + 1));
-    else map.set(part, '');
-  }
-  for (const header of setCookieHeaders) {
-    const nameValue = header.split(';')[0];
-    if (!nameValue) continue;
-    const eq = nameValue.indexOf('=');
-    if (eq >= 0) map.set(nameValue.slice(0, eq), nameValue.slice(eq + 1));
-  }
-  return Array.from(map.entries()).map(([k, v]) => `${k}=${v}`).join('; ');
-}
+export { mergeSetCookies };
 
 export function extractCsrf(cookies: string): string {
   const parts = cookies.split('; ').filter(Boolean);

--- a/src/connection/auth/oauth-provider.ts
+++ b/src/connection/auth/oauth-provider.ts
@@ -339,8 +339,6 @@ function hostnameOf(raw: string): string {
   }
 }
 
-export { mergeSetCookies };
-
 export function extractCsrf(cookies: string): string {
   const parts = cookies.split('; ').filter(Boolean);
   for (const part of parts) {

--- a/src/connection/auth/saas/cluster-session.ts
+++ b/src/connection/auth/saas/cluster-session.ts
@@ -105,9 +105,6 @@ export class SaasClusterSession {
     const qs = new URLSearchParams({ tenant: runtimeId, deviceCategory: '0' });
     if (tid) qs.set('tid', tid);
     const authUrl = `https://${clusterHost}/auth?${qs}`;
-    if (authUrl.includes('/tab/')) {
-      return err(new ConnectionError('AUTHENTICATETOKEN must not use a tab path'));
-    }
     this.log.info('saas-web: AUTHENTICATETOKEN', { hasAccess: Boolean(auth.accessToken), hasCode: Boolean(auth.authorizationCode) });
     const id = `|${randomUUID().replace(/-/g, '')}.${randomUUID().replace(/-/g, '').slice(0, 16)}`;
     const page = await this.request(jar, authUrl, {

--- a/src/connection/auth/saas/cookie-jar.ts
+++ b/src/connection/auth/saas/cookie-jar.ts
@@ -133,6 +133,11 @@ function parseSetCookie(header: string, req: URL): CookieRecord | undefined {
     const val = aEq < 0 ? '' : attr.slice(aEq + 1).trim();
     if (key === 'domain' && val) {
       const d = val.replace(/^\./, '').toLowerCase();
+      // Reject a Domain scoped to a bare public suffix (a single label such as
+      // "com" or "localhost"). Such a cookie would otherwise attach to every
+      // host under that suffix the jar later contacts. A real registrable
+      // domain (dynamics.com) has at least two labels and is kept.
+      if (isBarePublicSuffix(d)) return undefined;
       if (!hostInDomain(req.hostname, d)) return undefined;
       domain = d;
       hostOnly = false;
@@ -157,6 +162,16 @@ function defaultPath(pathname: string): string {
   const i = pathname.lastIndexOf('/');
   if (i <= 0) return '/';
   return pathname.slice(0, i);
+}
+
+/**
+ * A domain with no dot is a bare public suffix / TLD (e.g. "com", "localhost").
+ * No legitimate cookie for a BC/ESTS host is scoped this broadly. This is a
+ * pragmatic guard, not a full Public Suffix List: multi-label registrable
+ * domains (dynamics.com) are allowed exactly as a browser would.
+ */
+function isBarePublicSuffix(domain: string): boolean {
+  return !domain.includes('.');
 }
 
 function hostInDomain(host: string, domain: string): boolean {

--- a/src/connection/auth/saas/html-extract.ts
+++ b/src/connection/auth/saas/html-extract.ts
@@ -1,5 +1,11 @@
 import type { DeploymentReady, FixedEndPointAuth } from './ests-types.js';
 
+/** BC Online clusters always live under dynamics.com (e.g. *.appservices.*.businesscentral.dynamics.com). */
+function isBcClusterHost(hostname: string): boolean {
+  const h = hostname.toLowerCase();
+  return h === 'dynamics.com' || h.endsWith('.dynamics.com');
+}
+
 export function parseBalancedObject(src: string, from: number): Record<string, unknown> | undefined {
   const start = src.indexOf('{', from);
   if (start < 0) return undefined;
@@ -143,6 +149,11 @@ export function parseDeploymentJson(text: string): DeploymentReady | undefined {
   let tid = '';
   try {
     const url = new URL(clusterAddress);
+    // The cluster address drives the /csh WebSocket and the AUTHENTICATETOKEN
+    // POST that carries the access token. Only accept an https host under
+    // dynamics.com so a tampered deployment response cannot redirect either to
+    // an attacker-controlled origin.
+    if (url.protocol !== 'https:' || !isBcClusterHost(url.hostname)) return undefined;
     if (!runtimeId) runtimeId = url.searchParams.get('tenant') ?? '';
     tid = url.searchParams.get('tid') ?? '';
   } catch {

--- a/src/connection/auth/set-cookie-merge.ts
+++ b/src/connection/auth/set-cookie-merge.ts
@@ -1,0 +1,51 @@
+/**
+ * Merge `Set-Cookie` response headers into an existing `name=value; …` cookie
+ * string, honoring deletions. A server clears a cookie by sending `Max-Age=0`
+ * (or a negative Max-Age) or an `Expires` date in the past; such a header must
+ * REMOVE the cookie, not record it as a blank value that keeps being sent.
+ *
+ * Shared by the two inline auth cookie merges (OAuth bootstrap and NTLM
+ * sign-in). This is a request-cookie string builder, not a full jar: it tracks
+ * only name/value and deletion, which is all the pre-`/csh` redirect chains
+ * need. Domain/Path-scoped storage lives in `saas/cookie-jar.ts`.
+ */
+export function mergeSetCookies(existing: string, setCookieHeaders: string[]): string {
+  const map = new Map<string, string>();
+  for (const part of existing.split('; ').filter(Boolean)) {
+    const eq = part.indexOf('=');
+    if (eq >= 0) map.set(part.slice(0, eq), part.slice(eq + 1));
+    else map.set(part, '');
+  }
+  for (const header of setCookieHeaders) {
+    const segments = header.split(';');
+    const nameValue = segments[0];
+    if (!nameValue) continue;
+    const eq = nameValue.indexOf('=');
+    if (eq < 0) continue;
+    const name = nameValue.slice(0, eq);
+    const value = nameValue.slice(eq + 1);
+    if (isDeletion(segments.slice(1))) {
+      map.delete(name);
+    } else {
+      map.set(name, value);
+    }
+  }
+  return Array.from(map.entries()).map(([k, v]) => `${k}=${v}`).join('; ');
+}
+
+/** A Set-Cookie deletes when Max-Age <= 0 or Expires is in the past. */
+function isDeletion(attributes: string[]): boolean {
+  for (const attr of attributes) {
+    const eq = attr.indexOf('=');
+    const key = (eq < 0 ? attr : attr.slice(0, eq)).trim().toLowerCase();
+    const val = eq < 0 ? '' : attr.slice(eq + 1).trim();
+    if (key === 'max-age') {
+      const secs = Number(val);
+      if (Number.isFinite(secs) && secs <= 0) return true;
+    } else if (key === 'expires') {
+      const t = Date.parse(val);
+      if (!Number.isNaN(t) && t <= Date.now()) return true;
+    }
+  }
+  return false;
+}

--- a/src/connection/auth/set-cookie-merge.ts
+++ b/src/connection/auth/set-cookie-merge.ts
@@ -33,19 +33,29 @@ export function mergeSetCookies(existing: string, setCookieHeaders: string[]): s
   return Array.from(map.entries()).map(([k, v]) => `${k}=${v}`).join('; ');
 }
 
-/** A Set-Cookie deletes when Max-Age <= 0 or Expires is in the past. */
+/**
+ * A Set-Cookie deletes when Max-Age <= 0, or (absent a valid Max-Age) Expires
+ * is in the past. Per RFC 6265, Max-Age takes precedence over Expires, so a
+ * positive Max-Age keeps the cookie even alongside a past Expires. An empty or
+ * non-numeric Max-Age is ignored (falls through to Expires).
+ */
 function isDeletion(attributes: string[]): boolean {
+  let maxAge: number | undefined;
+  let expiresInPast: boolean | undefined;
   for (const attr of attributes) {
     const eq = attr.indexOf('=');
     const key = (eq < 0 ? attr : attr.slice(0, eq)).trim().toLowerCase();
     const val = eq < 0 ? '' : attr.slice(eq + 1).trim();
     if (key === 'max-age') {
-      const secs = Number(val);
-      if (Number.isFinite(secs) && secs <= 0) return true;
+      if (val !== '') {
+        const secs = Number(val);
+        if (Number.isFinite(secs)) maxAge = secs;
+      }
     } else if (key === 'expires') {
       const t = Date.parse(val);
-      if (!Number.isNaN(t) && t <= Date.now()) return true;
+      if (!Number.isNaN(t)) expiresInPast = t <= Date.now();
     }
   }
-  return false;
+  if (maxAge !== undefined) return maxAge <= 0;
+  return expiresInPast === true;
 }

--- a/src/mcp/tool-registry.ts
+++ b/src/mcp/tool-registry.ts
@@ -34,6 +34,13 @@ export interface ToolDefinition {
   inputSchema: Record<string, unknown>;
   zodSchema: z.ZodType;
   execute: (input: unknown) => Promise<unknown>;
+  /**
+   * True when the tool works without a `/csh` web-client session (its
+   * `execute` reaches BC through a session-independent path, e.g. OData).
+   * The server entry points run such tools directly instead of forcing
+   * session creation. Defaults to false/undefined (session required).
+   */
+  sessionIndependent?: boolean;
 }
 
 export interface Operations {

--- a/src/operations/query.tool.ts
+++ b/src/operations/query.tool.ts
@@ -12,6 +12,10 @@ When to use bc_query: structured data retrieval over standard BC entities, when 
 When NOT to use bc_query: do not use for UI-driven flows (navigating pages, clicking buttons, filling forms — use bc_open_page + bc_execute_action for those). Do not use bc_query for posting, writing, or triggering BC business logic — OData reads are read-only; use bc_write_data and bc_execute_action for mutations. Do not use for custom/extension entities not in the Standard API v2.0 — those require the UI WebSocket tools. Auth: on-prem NavUserPassword uses HTTP Basic; BC Online (SaaS) uses device-code — when sign-in is needed the tool returns DEVICE_LOGIN_REQUIRED with a verification URL and code to show the user, and a retry after they sign in runs the query. bc_query does not need a /csh WebSocket session and does not open the SaaS sign-in window.`,
     inputSchema: toMcpJsonSchema(QuerySchema),
     zodSchema: QuerySchema,
+    // bc_query reaches BC over OData (HTTP Basic on-prem, device-code OAuth on
+    // SaaS); it never needs the /csh web-client session, so the servers can run
+    // it before a session exists.
+    sessionIndependent: true,
     execute: (input) => ops.query.execute(input as Parameters<typeof ops.query.execute>[0]),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,7 @@ import { WizardNavigateOperation } from './operations/wizard-navigate.js';
 import { DownloadService } from './services/download-service.js';
 import { LookupService } from './services/lookup-service.js';
 import { LookupOperation } from './operations/lookup.js';
-import { QueryOperation, createQueryOperation } from './operations/query.js';
+import { createQueryOperation } from './operations/query.js';
 import { buildToolRegistry, type Operations } from './mcp/tool-registry.js';
 import { MCPHandler } from './mcp/handler.js';
 import { PROMPTS } from './mcp/prompts.js';
@@ -120,14 +120,15 @@ async function main() {
     await ensureSessionTools();
   }
 
-  // MCP tools/list and bc_query must work before a /csh session exists
-  // (SaaS OAuth can serve OData without the first-party web-client cookie).
+  // MCP tools/list and session-independent tools (e.g. bc_query over OData)
+  // must work before a /csh session exists. A session-independent tool's own
+  // execute already reaches BC without a session, so run it directly.
   const staticTools = buildServices({} as BCSession).tools;
   const lazyTools = staticTools.map(toolDef => ({
     ...toolDef,
     execute: async (input: unknown) => {
-      if (toolDef.name === 'bc_query') {
-        return queryOperation.execute(input as Parameters<QueryOperation['execute']>[0]);
+      if (toolDef.sessionIndependent) {
+        return toolDef.execute(input);
       }
       const tools = await ensureSessionTools();
       const resolved = tools.find(t => t.name === toolDef.name);

--- a/src/stdio-server.ts
+++ b/src/stdio-server.ts
@@ -33,7 +33,7 @@ import { WizardNavigateOperation } from './operations/wizard-navigate.js';
 import { DownloadService } from './services/download-service.js';
 import { LookupService } from './services/lookup-service.js';
 import { LookupOperation } from './operations/lookup.js';
-import { QueryOperation, createQueryOperation } from './operations/query.js';
+import { createQueryOperation } from './operations/query.js';
 import { buildToolRegistry, type Operations } from './mcp/tool-registry.js';
 import { MCPHandler } from './mcp/handler.js';
 import { PROMPTS } from './mcp/prompts.js';
@@ -132,11 +132,12 @@ async function main() {
   const lazyTools = staticTools.map(toolDef => ({
     ...toolDef,
     execute: async (input: unknown) => {
-      // bc_query talks to the OData API and must not require a /csh session.
-      // SaaS OAuth can obtain an API token even when the first-party web-client
-      // cookie session (needed for /csh) cannot be established.
-      if (toolDef.name === 'bc_query') {
-        return queryOperation.execute(input as Parameters<QueryOperation['execute']>[0]);
+      // Session-independent tools (e.g. bc_query over OData) must not require a
+      // /csh session — SaaS OAuth can obtain an API token even when the
+      // first-party web-client cookie session cannot be established. Their own
+      // execute already reaches BC without a session, so run it directly.
+      if (toolDef.sessionIndependent) {
+        return toolDef.execute(input);
       }
       const tools = await ensureSession();
       const resolved = tools.find(t => t.name === toolDef.name);

--- a/tests/unit/oauth-provider.test.ts
+++ b/tests/unit/oauth-provider.test.ts
@@ -367,6 +367,22 @@ describe('OAuthAuthProvider device-code state machine (fail-fast)', () => {
     expect(pendingCache().load(CLIENT, TENANT)?.userCode).toBe('KEEP-CODE');
   });
 
+  it('pending + non-JSON 200 on poll (captive portal): keeps the pending code, does not churn', async () => {
+    // A proxy/captive-portal HTTP 200 that is not a token JSON yields the
+    // synthetic oauthError 'http_200' (no real OAuth error field). Treating it
+    // as a hard failure would clear the code the user is mid-typing.
+    const start = vi.fn();
+    const provider = makeProvider(stubClient({
+      startDeviceCode: start,
+      pollDeviceCodeOnce: async () => err(new AuthenticationError('Token request failed: HTTP 200', { oauthError: 'http_200' })),
+    }));
+    seedPending('KEEP-CODE');
+
+    expect(await provider.getAccessToken()).toBeUndefined();
+    expect(pendingCache().load(CLIENT, TENANT)?.userCode).toBe('KEEP-CODE');
+    expect(start).not.toHaveBeenCalled();
+  });
+
   it('authenticate() surfaces DEVICE_LOGIN_REQUIRED as a Result error (non-retryable for SessionManager)', async () => {
     const provider = makeProvider(stubClient());
     const result = await provider.authenticate();

--- a/tests/unit/oauth-provider.test.ts
+++ b/tests/unit/oauth-provider.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { OAuthAuthProvider, mergeSetCookies, extractCsrf } from '../../src/connection/auth/oauth-provider.js';
+import { OAuthAuthProvider, extractCsrf } from '../../src/connection/auth/oauth-provider.js';
+import { mergeSetCookies } from '../../src/connection/auth/set-cookie-merge.js';
 import { OAuthTokenClient, type TokenSet } from '../../src/connection/auth/oauth-token-client.js';
 import { FileTokenCache, FilePendingDeviceCache } from '../../src/connection/auth/token-cache.js';
 import { AuthenticationError, DeviceLoginRequiredError } from '../../src/core/errors.js';
@@ -365,6 +366,21 @@ describe('OAuthAuthProvider device-code state machine (fail-fast)', () => {
 
     expect(await provider.getAccessToken()).toBeUndefined();
     expect(pendingCache().load(CLIENT, TENANT)?.userCode).toBe('KEEP-CODE');
+  });
+
+  it('pending + bodyless 4xx on poll: keeps the pending code (transient, no churn)', async () => {
+    // A 4xx with no OAuth JSON error body yields the synthetic 'http_400' (a
+    // real hard failure always carries a named error like expired_token).
+    const start = vi.fn();
+    const provider = makeProvider(stubClient({
+      startDeviceCode: start,
+      pollDeviceCodeOnce: async () => err(new AuthenticationError('Token request failed: HTTP 400', { oauthError: 'http_400' })),
+    }));
+    seedPending('KEEP-CODE');
+
+    expect(await provider.getAccessToken()).toBeUndefined();
+    expect(pendingCache().load(CLIENT, TENANT)?.userCode).toBe('KEEP-CODE');
+    expect(start).not.toHaveBeenCalled();
   });
 
   it('pending + non-JSON 200 on poll (captive portal): keeps the pending code, does not churn', async () => {

--- a/tests/unit/saas-cookie-jar.test.ts
+++ b/tests/unit/saas-cookie-jar.test.ts
@@ -25,6 +25,21 @@ describe('CookieJar', () => {
     expect(jar.hasPortalAuth(TENANT)).toBe(true);
   });
 
+  it('rejects a Set-Cookie scoped to a bare public suffix so it cannot over-scope', () => {
+    const jar = new CookieJar();
+    jar.absorb(response(['tracker=1; Domain=com; Path=/; Secure']), PORTAL);
+    // A Domain of a bare public suffix (e.g. "com") would otherwise attach to
+    // every *.com host the jar contacts. It must not be stored at all.
+    expect(jar.headerFor(PORTAL)).not.toContain('tracker');
+    expect(jar.headerFor('https://evil.example.com/')).not.toContain('tracker');
+  });
+
+  it('keeps a Set-Cookie scoped to a real registrable domain (dynamics.com)', () => {
+    const jar = new CookieJar();
+    jar.absorb(response(['shared=1; Domain=businesscentral.dynamics.com; Path=/; Secure']), PORTAL);
+    expect(jar.headerFor(PORTAL)).toContain('shared=1');
+  });
+
   it('does not send ESTSAUTH from login.microsoftonline.com to the cluster', () => {
     const jar = new CookieJar();
     jar.absorb(response([

--- a/tests/unit/saas-deployment-parse.test.ts
+++ b/tests/unit/saas-deployment-parse.test.ts
@@ -73,4 +73,13 @@ describe('parseDeploymentJson', () => {
       data: `http://${HOST}/?tenant=${RUNTIME}&tid=${TID}`,
     }))).toBeUndefined();
   });
+
+  it('rejects a userinfo-smuggled host (dynamics.com@evil.com)', () => {
+    // The real host is evil.com; only the userinfo looks like dynamics.com.
+    expect(parseDeploymentJson(JSON.stringify({
+      status: 'Ready',
+      runtimeId: RUNTIME,
+      data: `https://dynamics.com@evil.com/?tenant=${RUNTIME}&tid=${TID}`,
+    }))).toBeUndefined();
+  });
 });

--- a/tests/unit/saas-deployment-parse.test.ts
+++ b/tests/unit/saas-deployment-parse.test.ts
@@ -49,4 +49,28 @@ describe('parseDeploymentJson', () => {
     expect(parseDeploymentJson('not-json')).toBeUndefined();
     expect(parseDeploymentJson(JSON.stringify({ status: 'Ready' }))).toBeUndefined();
   });
+
+  it('rejects a cluster address whose host is not under dynamics.com', () => {
+    expect(parseDeploymentJson(JSON.stringify({
+      status: 'Ready',
+      runtimeId: RUNTIME,
+      data: `https://evil.example.com/?tenant=${RUNTIME}&tid=${TID}`,
+    }))).toBeUndefined();
+  });
+
+  it('rejects a look-alike suffix host (dynamics.com.evil.com)', () => {
+    expect(parseDeploymentJson(JSON.stringify({
+      status: 'Ready',
+      runtimeId: RUNTIME,
+      data: `https://dynamics.com.evil.com/?tenant=${RUNTIME}&tid=${TID}`,
+    }))).toBeUndefined();
+  });
+
+  it('rejects a non-https cluster address', () => {
+    expect(parseDeploymentJson(JSON.stringify({
+      status: 'Ready',
+      runtimeId: RUNTIME,
+      data: `http://${HOST}/?tenant=${RUNTIME}&tid=${TID}`,
+    }))).toBeUndefined();
+  });
 });

--- a/tests/unit/set-cookie-merge.test.ts
+++ b/tests/unit/set-cookie-merge.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { mergeSetCookies } from '../../src/connection/auth/set-cookie-merge.js';
+
+describe('mergeSetCookies', () => {
+  it('adds new cookies and overwrites existing by name', () => {
+    expect(mergeSetCookies('a=1; b=2', ['b=3; Path=/', 'c=4; Secure'])).toBe('a=1; b=3; c=4');
+  });
+
+  it('honors a Max-Age=0 deletion by removing the cookie', () => {
+    expect(mergeSetCookies('a=1; b=2', ['b=; Max-Age=0'])).toBe('a=1');
+  });
+
+  it('honors a negative Max-Age deletion', () => {
+    expect(mergeSetCookies('a=1; b=2', ['b=whatever; Max-Age=-1'])).toBe('a=1');
+  });
+
+  it('honors an Expires-in-the-past deletion', () => {
+    expect(mergeSetCookies('a=1', ['a=; Expires=Thu, 01 Jan 1970 00:00:00 GMT'])).toBe('');
+  });
+
+  it('keeps a cookie whose Expires is in the future', () => {
+    expect(mergeSetCookies('', ['a=1; Expires=Tue, 19 Jan 2038 03:14:07 GMT'])).toBe('a=1');
+  });
+
+  it('does not treat a normal cookie value as a deletion', () => {
+    expect(mergeSetCookies('', ['a=1; Path=/; Secure; HttpOnly'])).toBe('a=1');
+  });
+});

--- a/tests/unit/set-cookie-merge.test.ts
+++ b/tests/unit/set-cookie-merge.test.ts
@@ -25,4 +25,16 @@ describe('mergeSetCookies', () => {
   it('does not treat a normal cookie value as a deletion', () => {
     expect(mergeSetCookies('', ['a=1; Path=/; Secure; HttpOnly'])).toBe('a=1');
   });
+
+  it('honors RFC 6265 Max-Age-over-Expires precedence: positive Max-Age keeps despite a past Expires', () => {
+    expect(mergeSetCookies('a=1', ['a=x; Max-Age=100; Expires=Thu, 01 Jan 1970 00:00:00 GMT'])).toBe('a=x');
+  });
+
+  it('ignores an empty Max-Age= (not a deletion)', () => {
+    expect(mergeSetCookies('a=1', ['a=x; Max-Age='])).toBe('a=x');
+  });
+
+  it('deletes on Max-Age=0 even with a future Expires (Max-Age wins)', () => {
+    expect(mergeSetCookies('a=1', ['a=x; Max-Age=0; Expires=Tue, 19 Jan 2038 03:14:07 GMT'])).toBe('');
+  });
 });

--- a/tests/unit/tool-descriptions.test.ts
+++ b/tests/unit/tool-descriptions.test.ts
@@ -36,6 +36,11 @@ describe('tool descriptions', () => {
     }
   });
 
+  it('marks bc_query as the only session-independent tool', () => {
+    const independent = tools.filter(t => t.sessionIndependent).map(t => t.name);
+    expect(independent).toEqual(['bc_query']);
+  });
+
   it('bc_execute_action describes create/delete workflow', () => {
     const tool = tools.find(t => t.name === 'bc_execute_action')!;
     expect(tool.description).toContain('New');


### PR DESCRIPTION
## Summary

The hardening/cleanup batch from the PR #12 review (findings #11-16) — the ones that need no live SaaS tenant. The reachable-path batch (#5-10) is @FBakkensen's follow-up, since those hinge on real BC Online wire behavior and my only box is an on-prem NavUserPassword container.

All findings were fixed test-first (each new test was watched failing for the exact reason described before the fix).

## Findings addressed

- **#11 - reject bare public-suffix cookies** (`saas/cookie-jar.ts`). `CookieJar.absorb` accepted a `Set-Cookie` whose `Domain` is a single-label public suffix (e.g. `com`), which would attach to every host under that suffix the jar later contacted. Dropped at parse time; real registrable domains (`dynamics.com`, >=2 labels) are unaffected, matching browser behavior. Pragmatic guard, not a full PSL.
- **#12 - honor `Set-Cookie` deletions** (`set-cookie-merge.ts`, `oauth-provider.ts`, `ntlm-provider.ts`). Both inline cookie merges stored `name=value` only, so a server deletion (`Max-Age=0` / past `Expires`) became a blank value that kept being sent. Extracted one shared `mergeSetCookies` that honors deletions and routed both providers through it (removes the duplicated NTLM merge).
- **#13 - keep the device code on ambiguous polls** (`oauth-provider.ts`). A non-JSON token-endpoint 200 (captive portal/proxy) surfaces as the synthetic `oauthError: 'http_200'`, which the device-code state machine treated as a hard failure and cleared the pending code the user was mid-typing. Any synthetic `http_<status>` (no OAuth error body) is now treated as transient — the pending code is kept, same as a network failure or 5xx.
- **#14 - allowlist the cluster host** (`saas/html-extract.ts`). `parseDeploymentJson` now requires the cluster address to be an https host under `dynamics.com`. That address drives the `/csh` WebSocket and the `AUTHENTICATETOKEN` POST carrying the access token, so a tampered deployment response can't redirect either to an attacker origin. (The real cluster host, `*.appservices.*.businesscentral.dynamics.com`, is covered.)
- **#15 - `sessionIndependent` flag** (`tool-registry.ts`, `query.tool.ts`, `server.ts`, `stdio-server.ts`). Both entry points special-cased `toolDef.name === 'bc_query'` to run it before a `/csh` session exists. Replaced with a `sessionIndependent` flag on `ToolDefinition` (set on `bc_query`); each entry point now runs any session-independent tool via its own `execute`. A future session-free tool needs no server edits, and a rename of `bc_query` can't silently break the bypass.
- **#16 - remove a dead guard** (`saas/cluster-session.ts`). `if (authUrl.includes('/tab/'))` was unreachable — `authUrl` is built from a bare cluster host plus a querystring.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 943 passed (97 files), incl. new tests for #11-15
- [ ] On-prem integration not run here: `cronus28` is unreachable in my current session. #12 touches the on-prem NTLM cookie merge, so I isolated it — with my changes stashed the connection test fails identically, confirming the failure is environmental, not this change. The NTLM merge is behavior-preserving on the non-deletion path. Worth a green on-prem run before merge.

## Notes

- #9 and #10 were left with the #5-10 batch (they sit in the same odata/REST error-plumbing area @FBakkensen is taking).
- Depends on #12 being merged (branched off `master` after the squash).
